### PR TITLE
Fix command so that the example can run

### DIFF
--- a/browser-example/package.json
+++ b/browser-example/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "prepare": "theia generate --target=browser && theia build",
-    "start": "theia browser",
+    "start": "theia start",
     "watch": "theia build --watch"
   }
 }


### PR DESCRIPTION
Minor change so that the example can run again. 

Alternatively you receive this error right now

```
$ yarn start
yarn run v1.17.3
warning package.json: No license field
$ theia browser
non-existing or no command specified
Commands:
  start             start the browser backend
  clean             clean for the browser target
  build             webpack the browser frontend
  rebuild           rebuild native node modules for the browser
  rebuild:browser   rebuild native node modules for the browser
  rebuild:electron  rebuild native node modules for the electron

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```