### PR TITLE
Make browser example runnable

### DIFF
--- a/browser-example/package.json
+++ b/browser-example/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "prepare": "theia generate --target=browser && theia build",
-    "start": "theia browser",
+    "start": "theia start",
     "watch": "theia build --watch"
   }
 }


### PR DESCRIPTION
previous `browser` command is not available anymore from theia command line.